### PR TITLE
return parent dispatch result

### DIFF
--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -75,7 +75,7 @@ if ( ! class_exists( 'WP_Background_Process' ) ) {
 			$this->schedule_event();
 
 			// Perform remote post.
-			parent::dispatch();
+			return parent::dispatch();
 		}
 
 		/**


### PR DESCRIPTION
Useful to return this so it is available if extending or handling errors.

This may contain a wp_remote_post error for example.