### PR TITLE
Allow running multiple tasks using same processor with task name

### DIFF
--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -497,10 +497,11 @@ if ( ! class_exists( 'WP_Background_Process' ) ) {
 		 * item from the queue.
 		 *
 		 * @param mixed $item Queue item to iterate over.
+		 * @param string|null $task_name Run multiple task with task name.
 		 *
 		 * @return mixed
 		 */
-		abstract protected function task( $item );
+		abstract protected function task( $item, $task_name=null );
 
 	}
 }


### PR DESCRIPTION
It would be nice to have the feature to allow running multiple tasks using the same processor with task name. 

**Consider the situation -** 

I have processor name `Cleanup_Processor`, now I would like to run multiple tasks like `cleanup-zip` and `cleanup-files`.  If we add the $task_name param, I could write the code for both tasks in the `task()` method without creating another class. 
