### PR TITLE
Add option to choose the REST API over the AJAX API to make requests

### DIFF
--- a/classes/wp-async-request.php
+++ b/classes/wp-async-request.php
@@ -60,7 +60,7 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 
 			add_action( 'rest_api_init', function () {
 				register_rest_route( 'background_process/v1', $this->identifier, array(
-					'methods'	 => 'GET',
+					'methods'	 => 'POST',
 					'callback' => array( $this, 'maybe_handle' ),
 				));
 			});
@@ -116,7 +116,7 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 				return $this->query_url;
 			}
 
-			return rest_url( $this->identifier );
+			return rest_url( 'background_process/v1/' . $this->identifier  );
 		}
 
 		/**
@@ -131,7 +131,6 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 
 			return array(
 				'timeout'   => 0.01,
-				'blocking'  => false,
 				'body'      => $this->data,
 				'cookies'   => $_COOKIE,
 				'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
@@ -150,8 +149,8 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 			//check_ajax_referer( $this->identifier, 'nonce' );
 
 			$this->handle();
-
-			wp_die();
+			return rest_ensure_response( array('success' => true) );
+			//wp_die();
 		}
 
 		/**

--- a/classes/wp-async-request.php
+++ b/classes/wp-async-request.php
@@ -58,8 +58,12 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 		public function __construct() {
 			$this->identifier = $this->prefix . '_' . $this->action;
 
-			add_action( 'wp_ajax_' . $this->identifier, array( $this, 'maybe_handle' ) );
-			add_action( 'wp_ajax_nopriv_' . $this->identifier, array( $this, 'maybe_handle' ) );
+			add_action( 'rest_api_init', function () {
+				register_rest_route( 'background_process/v1', $this->identifier, array(
+					'methods'	 => 'GET',
+					'callback' => array( $this, 'maybe_handle' ),
+				));
+			});
 		}
 
 		/**
@@ -98,8 +102,7 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 			}
 
 			return array(
-				'action' => $this->identifier,
-				'nonce'  => wp_create_nonce( $this->identifier ),
+				'_wpnonce'  => wp_create_nonce( 'wp_rest' ),
 			);
 		}
 
@@ -113,7 +116,7 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 				return $this->query_url;
 			}
 
-			return admin_url( 'admin-ajax.php' );
+			return rest_url( $this->identifier );
 		}
 
 		/**
@@ -144,7 +147,7 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 			// Don't lock up other requests while processing
 			session_write_close();
 
-			check_ajax_referer( $this->identifier, 'nonce' );
+			//check_ajax_referer( $this->identifier, 'nonce' );
 
 			$this->handle();
 

--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -172,7 +172,7 @@ if ( ! class_exists( 'WP_Background_Process' ) ) {
 				wp_die();
 			}
 
-			check_ajax_referer( $this->identifier, 'nonce' );
+			//check_ajax_referer( $this->identifier, 'nonce' );
 
 			$this->handle();
 

--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -164,22 +164,19 @@ if ( ! class_exists( 'WP_Background_Process' ) ) {
 
 			if ( $this->is_process_running() ) {
 				// Background process already running.
-				return rest_ensure_response( array('success' => true) );
-				//wp_die();
+				return $this->send_or_die();
 			}
 
 			if ( $this->is_queue_empty() ) {
 				// No data to process.
-				return rest_ensure_response( array('success' => true) );
-				//wp_die();
+				return $this->send_or_die();
 			}
 
-			//check_ajax_referer( $this->identifier, 'nonce' );
+			$this->check_nonce();
 
 			$this->handle();
 
-			return rest_ensure_response( array('success' => true) );
-			//wp_die();
+			return $this->send_or_die();
 		}
 
 		/**
@@ -333,9 +330,8 @@ if ( ! class_exists( 'WP_Background_Process' ) ) {
 			} else {
 				$this->complete();
 			}
-			return rest_ensure_response( array('success' => true) );
 
-			wp_die();
+			return $this->send_or_die();
 		}
 
 		/**

--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -164,19 +164,22 @@ if ( ! class_exists( 'WP_Background_Process' ) ) {
 
 			if ( $this->is_process_running() ) {
 				// Background process already running.
-				wp_die();
+				return rest_ensure_response( array('success' => true) );
+				//wp_die();
 			}
 
 			if ( $this->is_queue_empty() ) {
 				// No data to process.
-				wp_die();
+				return rest_ensure_response( array('success' => true) );
+				//wp_die();
 			}
 
 			//check_ajax_referer( $this->identifier, 'nonce' );
 
 			$this->handle();
 
-			wp_die();
+			return rest_ensure_response( array('success' => true) );
+			//wp_die();
 		}
 
 		/**
@@ -330,6 +333,7 @@ if ( ! class_exists( 'WP_Background_Process' ) ) {
 			} else {
 				$this->complete();
 			}
+			return rest_ensure_response( array('success' => true) );
 
 			wp_die();
 		}


### PR DESCRIPTION
As stated in the following [Delicious Brains Article](https://deliciousbrains.com/comparing-wordpress-rest-api-performance-admin-ajax-php/), the WordPress REST API performs 15% faster than the AJAX API. The following PR defaults all requests to the AJAX API, but allows developers to choose to use the REST API instead by setting the `$use_rest` property in their child class to `true`.