### PR TITLE
Compare intval, since -1 can sometimes be a string

### DIFF
--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -367,7 +367,7 @@ if ( ! class_exists( 'WP_Background_Process' ) ) {
 				$memory_limit = '128M';
 			}
 
-			if ( ! $memory_limit || -1 === $memory_limit ) {
+			if ( ! $memory_limit || -1 === intval( $memory_limit ) ) {
 				// Unlimited, set to 32GB.
 				$memory_limit = '32000M';
 			}


### PR DESCRIPTION
When running tests I noticed my memory limit was a string `“-1”` which meant this check did not pass, and my memory limit ended up being negative :)