### PR TITLE
Fix cron_interval property support

### DIFF
--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -416,7 +416,7 @@ if ( ! class_exists( 'WP_Background_Process' ) ) {
 			$interval = apply_filters( $this->identifier . '_cron_interval', 5 );
 
 			if ( property_exists( $this, 'cron_interval' ) ) {
-				$interval = apply_filters( $this->identifier . '_cron_interval', $this->cron_interval_identifier );
+				$interval = apply_filters( $this->identifier . '_cron_interval', $this->cron_interval );
 			}
 
 			// Adds every 5 minutes to the existing schedules.


### PR DESCRIPTION
Currently if you define a cron_interval on your class, this will cause the interval to be set to the name of the cron_interval_identifier, rather than the value you've supplied in the property. 

This PR resolves that, although the code in question could benefit some other cleanups. Happy to raise a separate PR for those if there's any interest ...