### PR TITLE
Handle all shorthand memory_limit notations in get_memory_limit()

### DIFF
--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -367,12 +367,29 @@ if ( ! class_exists( 'WP_Background_Process' ) ) {
 				$memory_limit = '128M';
 			}
 
-			if ( ! $memory_limit || -1 === intval( $memory_limit ) ) {
+			if ( ! $memory_limit || -1 === (int) $memory_limit ) {
 				// Unlimited, set to 32GB.
-				$memory_limit = '32000M';
+				$memory_limit = '32G';
 			}
 
-			return intval( $memory_limit ) * 1024 * 1024;
+			return $this->shorthand_to_bytes( $memory_limit );
+		}
+
+		/**
+		 * Converts shorthand memory notation such as '128M' or '2G' to bytes.
+		 *
+		 * @see http://php.net/manual/en/faq.using.php#faq.using.shorthandbytes
+		 *
+		 * @param string $value the shorthand value
+		 * @return int
+		 */
+		protected function shorthand_to_bytes( $value ) {
+			switch ( strtolower( substr ( $value, -1 ) ) ) {
+				case 'g': return (int) $value * 1024 * 1024 * 1024;
+				case 'm': return (int) $value * 1024 * 1024;
+				case 'k': return (int) $value * 1024;
+				default:  return (int) $value;
+			}
 		}
 
 		/**


### PR DESCRIPTION
The current implementation of `get_memory_limit()` assumes that the memory limit set in the ini file is always in megabytes, when that value may be written as shorthand for `G`, `M`, `K`, or in bytes ([see docs here](http://php.net/manual/en/faq.using.php#faq.using.shorthandbytes))

This PR handles any valid value from the ini file, converting them all to bytes.

I ran into this initially when background tasks were not batching correctly and after a little digging found that my ini file had a memory limit of `2G` set, which was being incorrectly interpreted as `2M`, and I was exceeding memory on every request.