### PR TITLE
Add WP_Background_Processing namespace to classes

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -30,6 +30,7 @@
 	<rule ref="WordPress">
 		<!-- Unable to fix -->
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
+		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound"/>
 		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound"/>
 		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound"/>
 		<exclude name="WordPress.DB.DirectDatabaseQuery.NoCaching"/>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The recommended way to install this library in your project is by loading it thr
 composer require deliciousbrains/wp-background-processing
 ```
 
-It is highly recommended to prefix wrap the library class files using [the Mozart package](https://packagist.org/packages/coenjacobs/mozart), to prevent collisions with other projects using this same library.
+It is highly recommended to prefix wrap the library class files using [PHP-Scoper](https://packagist.org/packages/humbug/php-scoper), to prevent collisions with other projects using this same library.
 
 ## Usage
 
@@ -25,6 +25,8 @@ Async requests are useful for pushing slow one-off tasks such as sending emails 
 Extend the `WP_Async_Request` class:
 
 ```php
+use My_Plugin\PHP_Scoped\Namespace\WP_Background_Processing;
+
 class WP_Example_Request extends WP_Async_Request {
 
 	/**
@@ -99,6 +101,8 @@ Queues work on a first in first out basis, which allows additional items to be p
 Extend the `WP_Background_Process` class:
 
 ```php
+use My_Plugin\PHP_Scoped\Namespace\WP_Background_Processing;
+
 class WP_Example_Process extends WP_Background_Process {
 
 	/**

--- a/classes/wp-async-request.php
+++ b/classes/wp-async-request.php
@@ -5,6 +5,10 @@
  * @package WP-Background-Processing
  */
 
+namespace WP_Background_Processing;
+
+use WP_Error;
+
 /**
  * Abstract WP_Async_Request class.
  *

--- a/classes/wp-async-request.php
+++ b/classes/wp-async-request.php
@@ -7,8 +7,6 @@
 
 namespace WP_Background_Processing;
 
-use WP_Error;
-
 /**
  * Abstract WP_Async_Request class.
  *

--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -5,6 +5,11 @@
  * @package WP-Background-Processing
  */
 
+namespace WP_Background_Processing;
+
+use stdClass;
+use WP_Error;
+
 /**
  * Abstract WP_Background_Process class.
  *

--- a/classes/wp-background-process.php
+++ b/classes/wp-background-process.php
@@ -8,7 +8,6 @@
 namespace WP_Background_Processing;
 
 use stdClass;
-use WP_Error;
 
 /**
  * Abstract WP_Background_Process class.

--- a/tests/Test_WP_Background_Process.php
+++ b/tests/Test_WP_Background_Process.php
@@ -6,6 +6,7 @@
  */
 
 use PHPUnit\Framework\MockObject\MockObject;
+use WP_Background_Processing\WP_Background_Process;
 
 /**
  * Class Test_WP_Background_Process
@@ -42,7 +43,7 @@ class Test_WP_Background_Process extends WP_UnitTestCase {
 	 */
 	private function getWPBPProperty( string $name ) {
 		try {
-			$property = new ReflectionProperty( 'WP_Background_Process', $name );
+			$property = new ReflectionProperty( 'WP_Background_Processing\WP_Background_Process', $name );
 		} catch ( Exception $e ) {
 			return new WP_Error( $e->getCode(), $e->getMessage() );
 		}
@@ -61,7 +62,7 @@ class Test_WP_Background_Process extends WP_UnitTestCase {
 	 */
 	private function executeWPBPMethod( string $name, ...$args ) {
 		try {
-			$method = new ReflectionMethod( 'WP_Background_Process', $name );
+			$method = new ReflectionMethod( 'WP_Background_Processing\WP_Background_Process', $name );
 			$method->setAccessible( true );
 
 			return $method->invoke( $this->wpbp, ...$args );
@@ -76,7 +77,7 @@ class Test_WP_Background_Process extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_push_to_queue() {
-		$this->assertClassHasAttribute( 'data', 'WP_Background_Process', 'class has data property' );
+		$this->assertClassHasAttribute( 'data', 'WP_Background_Processing\WP_Background_Process', 'class has data property' );
 		$this->assertEmpty( $this->getWPBPProperty( 'data' ) );
 
 		$this->wpbp->push_to_queue( 'wibble' );
@@ -93,7 +94,7 @@ class Test_WP_Background_Process extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_save() {
-		$this->assertClassHasAttribute( 'data', 'WP_Background_Process', 'class has data property' );
+		$this->assertClassHasAttribute( 'data', 'WP_Background_Processing\WP_Background_Process', 'class has data property' );
 		$this->assertEmpty( $this->getWPBPProperty( 'data' ) );
 		$this->assertEmpty( $this->wpbp->get_batches(), 'no batches until save' );
 


### PR DESCRIPTION
Resolves #98

This will effectively be a breaking change for some people's use, so will necessitate being released as v2.0.0 with suitable warnings in the release note.

We'll do a beta release first to ensure all is well.